### PR TITLE
JSON.parse pushed down to request

### DIFF
--- a/core/tamtam.js
+++ b/core/tamtam.js
@@ -211,7 +211,17 @@ class TamTamBot extends EventEmitter {
         options.url = parameters.form.method.url;
         options.qs = parameters.form.query;
         options.body = JSON.stringify(parameters.form.body);
-        return request(null, options, function (error, response, body){});
+        return request(null, options)
+            .then(response => {
+                try{
+                    return JSON.parse(response)
+                } catch(e) {
+                    throw response
+                }
+            })
+            .catch(error_response => {
+                throw JSON.parse(error_response.error)
+            })
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tamtam-botapi",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "TamTam Bot API",
   "main": "./index.js",
   "directories": {

--- a/test/tamtam.js
+++ b/test/tamtam.js
@@ -132,13 +132,13 @@ describe('TamTamBotAPI', function tamtamSuite() {
                     let body = JSON.parse(response.body);
                     assert.ok(is.object(body));
                     assert.ok(is.equal(body.code, 'proto.payload'));
-                    assert.ok(is.equal(body.message, 'Cannot modify dialog info. Method is available for chats only.'));
+                    assert.ok(is.equal(body.message, 'Method is available for chats only.'));
                 })
             })
         });
 
         describe('#sendAction', function sendActionSuite() {
-            const actions = ['typing_on', 'typing_off', 'sending_photo', 'sending_video', 'sending_audio', 'mark_seen'];
+            const actions = ['typing_on', 'sending_file', 'sending_photo', 'sending_video', 'sending_audio', 'mark_seen'];
             actions.forEach(function (action) {
                 let body = {};
                 body.action = action;
@@ -160,7 +160,7 @@ describe('TamTamBotAPI', function tamtamSuite() {
                     assert.ok(is.object(body));
                     assert.ok(is.equal(body.code, 'proto.payload'));
                     //assert.ok(is.equal(body.message, '/action: instance value ("' + invalid_action + '") in unknown'));
-                    assert.ok(is.equal(body.message, '/action: instance value ("' + invalid_action + '") not found in enum (possible values: ["typing_on","typing_off","sending_photo","sending_video","sending_audio","mark_seen"])'));
+                    assert.ok(is.equal(body.message, 'action: value not found in enum. Possible values are: typing_on, sending_photo, sending_video, sending_audio, sending_file, mark_seen'));
                     //console.log(body.message);
                 })
             })

--- a/test/tamtam.js
+++ b/test/tamtam.js
@@ -43,7 +43,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
         describe('#getMyInfo', function getMyInfoSuite() {
             it('should return object with current bot info', function test() {
                 return bot_1.getMyInfo().then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.number(resp.user_id));
                     assert.ok(is.string(resp.name));
@@ -58,7 +57,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
                 body.name = 'Testing with CI #' + random;
                 body.description = 'Testing nodejs botapi with CI #'  + random;
                 return bot_1.editMyInfo(body).then( resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.name, body.name));
                     assert.ok(is.equal(resp.description, body.description));
@@ -71,7 +69,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
         describe('#getAllChats', function getAllChatsSuite() {
             it('should return object with information about chat that bot participated in', function test() {
                 return bot_1.getAllChats(1).then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(!is.undefined(resp.marker));
                 })
@@ -81,7 +78,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
         describe('#getChat', function getChatSuite() {
             it('should returns info about chat', function test() {
                 return bot_1.getChat(CHAT_ID_1).then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.type, 'chat'));
                     assert.ok(is.equal(resp.chat_id.toString(), CHAT_ID_1));
@@ -89,7 +85,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
             });
             it('should returns info about channel', function test() {
                 return bot_1.getChat(CHANNEL_ID).then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.type, 'channel'));
                     assert.ok(is.equal(resp.chat_id.toString(), CHANNEL_ID));
@@ -97,7 +92,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
             });
             it('should returns info about dialog', function test() {
                 return bot_1.getChat(DIALOG_ID).then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.type, 'dialog'));
                     assert.ok(is.equal(resp.chat_id.toString(), DIALOG_ID));
@@ -110,7 +104,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
                 body = {};
                 body.title = 'Test CI chat #1: ' + utils.randomInteger(0, 10000);
                 return bot_1.editChat(CHAT_ID_1, body).then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.title, body.title));
                 })
@@ -119,7 +112,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
                 body = {};
                 body.title = 'Test CI channel ' + utils.randomInteger(0, 10000);
                 return bot_1.editChat(CHANNEL_ID, body).then(resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.title, body.title));
                 })
@@ -128,11 +120,9 @@ describe('TamTamBotAPI', function tamtamSuite() {
                 let body = {};
                 body.title = 'Test CI dialog ' + utils.randomInteger(0, 10000);
                 return bot_1.editChat(DIALOG_ID, body).catch(res => {
-                    let response = JSON.parse(JSON.stringify(res.response));
-                    let body = JSON.parse(response.body);
-                    assert.ok(is.object(body));
-                    assert.ok(is.equal(body.code, 'proto.payload'));
-                    assert.ok(is.equal(body.message, 'Method is available for chats only.'));
+                    assert.ok(is.object(res));
+                    assert.ok(is.equal(res.code, 'proto.payload'));
+                    assert.ok(is.equal(res.message, 'Method is available for chats only.'));
                 })
             })
         });
@@ -144,7 +134,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
                 body.action = action;
                 it('should return true if request ' + JSON.stringify(body) + ' was successful', function test() {
                     return bot_1.sendAction(CHAT_ID_1, body).then(resp => {
-                        resp = JSON.parse(resp);
                         assert.ok(is.object(resp));
                         assert.ok(is.equal(resp.success, true));
                     });
@@ -155,12 +144,10 @@ describe('TamTamBotAPI', function tamtamSuite() {
                 let invalid_action = 'some_action';
                 body.action = invalid_action;
                 return bot_1.sendAction(DIALOG_ID, body).catch(res => {
-                    let response = JSON.parse(JSON.stringify(res.response));
-                    let body = JSON.parse(response.body);
-                    assert.ok(is.object(body));
-                    assert.ok(is.equal(body.code, 'proto.payload'));
+                    assert.ok(is.object(res));
+                    assert.ok(is.equal(res.code, 'proto.payload'));
                     //assert.ok(is.equal(body.message, '/action: instance value ("' + invalid_action + '") in unknown'));
-                    assert.ok(is.equal(body.message, 'action: value not found in enum. Possible values are: typing_on, sending_photo, sending_video, sending_audio, sending_file, mark_seen'));
+                    assert.ok(is.equal(res.message, 'action: value not found in enum. Possible values are: typing_on, sending_photo, sending_video, sending_audio, sending_file, mark_seen'));
                     //console.log(body.message);
                 })
             })
@@ -169,7 +156,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
         describe('#getMembership', function getMembershipSuite() {
             it('should returns chat membership info for current bot', function test() {
                 return bot_1.getMembership(CHAT_ID_1).then( resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.array(resp.permissions));
                     assert.ok(is.equal(resp.is_admin, true));
@@ -177,11 +163,9 @@ describe('TamTamBotAPI', function tamtamSuite() {
             });
             it('should returns error, because send chat_id from dialog', function test() {
                 return bot_1.getMembership(DIALOG_ID).catch( resp => {
-                    let response = JSON.parse(JSON.stringify(resp.response));
-                    let body = JSON.parse(response.body);
-                    assert.ok(is.object(body));
-                    assert.ok(is.equal(body.code, 'proto.payload'));
-                    assert.ok(is.equal(body.message, 'Method is available for chats only.'));
+                    assert.ok(is.object(resp));
+                    assert.ok(is.equal(resp.code, 'proto.payload'));
+                    assert.ok(is.equal(resp.message, 'Method is available for chats only.'));
                 })
             })
         });
@@ -201,7 +185,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
         describe('#getSubscriptions', function getSubscriptionsSuite() {
             it('should returns list of all subscriptions', function test() {
                 return bot_1.getSubscriptions().then( resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.subscriptions[0].url, url))
                 })
@@ -210,7 +193,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
         describe('#unsubscribe', function unsubscribeSuite() {
             it('should returns boolean', function test() {
                 return bot_1.unsubscribe(url).then( resp => {
-                    resp = JSON.parse(resp);
                     assert.ok(is.object(resp));
                     assert.ok(is.equal(resp.success, true));
                 })
@@ -225,7 +207,6 @@ describe('TamTamBotAPI', function tamtamSuite() {
             types.forEach(function (type) {
                 it('should return url', function test() {
                     return bot_1.getUploadUrl(type).then(resp => {
-                        resp = JSON.parse(resp);
                         assert.ok(is.object(resp));
                         assert.ok(!is.undefined(resp.url));
                     })

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,7 +36,6 @@ function randomInteger(min, max) {
 function isUserChatMember(token, chatId, userIds) {
     let bot = new TamTamBotApi(token);
     bot.getMembers(chatId, userIds).then(resp => {
-        resp = JSON.parse(resp);
         return resp.members;
     });
 }


### PR DESCRIPTION
Added parsing response and errors via JSON.parse to _request method. Now it is easier to handle responses from bot methods.

CI pipeline may not pass because the environment variables are not set, e.g. Error: Bot token not provided. Tests successfully pass on my machine.